### PR TITLE
A few improvements in the conversion interface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2020 University of Edinburgh, University of Oxford
+Copyright (C) 2020-2021 University of Oxford, University of Edinburgh
 Copyright note valid unless otherwise stated in individual files.
 All rights reserved.
 

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020, University of Oxford
+// Copyright (c) 2020-2021, University of Oxford, University of Edinburgh
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -143,6 +143,7 @@ class WholeBodyStateInterface {
     }
 
     msg.time = t;
+    msg.header.stamp = ros::Time(t);
 
     // Filling the centroidal state
     if (has_velocity) {

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <unordered_map>
 #include <cmath>
+#include <mutex>
 
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/container/aligned-vector.hpp>
@@ -167,6 +168,8 @@ class WholeBodyStateInterface {
       throw std::invalid_argument("Expected tau to be 0 or " + std::to_string(njoints_) + " but received " +
                                   std::to_string(tau.size()));
     }
+
+    std::lock_guard<std::mutex> guard(mutex_);
 
     // Filling the time information
     msg.time = t;
@@ -327,6 +330,8 @@ class WholeBodyStateInterface {
 
     t = msg.time;
 
+    std::lock_guard<std::mutex> guard(mutex_);
+
     // Retrieve the generalized position and velocity, and joint torques
     q(3) = msg.centroidal.base_orientation.x;
     q(4) = msg.centroidal.base_orientation.y;
@@ -379,6 +384,7 @@ class WholeBodyStateInterface {
   pinocchio::Model model_;  ///< Pinocchio model
   pinocchio::Data data_;    ///< Pinocchio data
   std::size_t njoints_;     ///< Number of joints
+  std::mutex mutex_;        ///< Mutex to prevent race condition on data_
 
   whole_body_state_msgs::WholeBodyState msg_;  ///< ROS message that contains the whole-body state
 

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -233,28 +233,28 @@ class WholeBodyStateInterface {
       if (static_cast<int>(frame_id) > model_.nframes) {
         throw std::runtime_error("Frame '" + contact_name + "' not found.");
       }
-      if (!isnan(contact.position.translation().norm())) {
+      if (contact.position.translation().allFinite()) {
         position_tmp_ = contact.position;
       } else {
         position_tmp_ = pinocchio::updateFramePlacement(model_, data_, frame_id);
       }
-      if (!isnan(contact.velocity.toVector().norm())) {
+      if (contact.velocity.toVector().allFinite()) {
         velocity_tmp_ = contact.velocity;
       } else {
         velocity_tmp_ =
             pinocchio::getFrameVelocity(model_, data_, frame_id, pinocchio::ReferenceFrame::LOCAL_WORLD_ALIGNED);
       }
       force_tmp_ = pinocchio::Force::Zero();
-      if (!isnan(contact.force.toVector().norm())) {
+      if (contact.force.toVector().allFinite()) {
         force_tmp_ = contact.force;
       }
-      if (!isnan(contact.surface_normal.norm())) {
+      if (contact.surface_normal.allFinite()) {
         nsurf_tmp_ = contact.surface_normal;
       } else {
         nsurf_tmp_ = Eigen::Vector3d::UnitZ();
       }
       double surface_friction = 1.;
-      if (contact.surface_friction != NAN) {
+      if (std::isfinite(contact.surface_friction)) {
         surface_friction = contact.surface_friction;
       }
       // Storing the contact position and velocity inside the message

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -87,7 +87,8 @@ class WholeBodyStateInterface {
    * @param[in] model     Pinocchio model
    * @param[in] frame_id  Frame name of the inertial system (default: odom)
    */
-  WholeBodyStateInterface(pinocchio::Model &model, const std::string frame_id = "odom") : model_(model), data_(model_) {
+  WholeBodyStateInterface(pinocchio::Model &model, const std::string frame_id = "odom")
+      : model_(model), data_(model_) {
     // Setup message
     msg_.header.frame_id = frame_id;
     njoints_ = model_.njoints - 2;
@@ -108,10 +109,9 @@ class WholeBodyStateInterface {
    * @return The ROS message that contains the whole-body state
    * @note TODO: Contact type and contact location / velocity are not yet supported.
    */
-  const whole_body_state_msgs::WholeBodyState& writeToMessage(double t, const Eigen::VectorXd &q,
-                                                       const Eigen::VectorXd &v = Eigen::VectorXd(),
-                                                       const Eigen::VectorXd &tau = Eigen::VectorXd(),
-                                                       std::unordered_map<std::string, ContactState> contacts = {}) {
+  const whole_body_state_msgs::WholeBodyState &writeToMessage(
+      double t, const Eigen::VectorXd &q, const Eigen::VectorXd &v = Eigen::VectorXd(),
+      const Eigen::VectorXd &tau = Eigen::VectorXd(), std::unordered_map<std::string, ContactState> contacts = {}) {
     toMsg(msg_, t, q, v, tau, contacts);
     return msg_;
   }

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -174,9 +174,9 @@ class WholeBodyStateInterface {
 
     // Filling the centroidal state
     if (has_velocity) {
-      pinocchio::centerOfMass(model_, data_, q);
-    } else {
       pinocchio::centerOfMass(model_, data_, q, v);
+    } else {
+      pinocchio::centerOfMass(model_, data_, q);
     }
     // Center of mass
     msg.centroidal.com_position.x = data_.com[0].x();

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -1,31 +1,10 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
 //
 // Copyright (c) 2020-2021, University of Oxford, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//  * Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of  nor the names of its contributors may be used to
-//    endorse or promote products derived from this software without specific
-//    prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
+///////////////////////////////////////////////////////////////////////////////
 
 #ifndef WHOLE_BODY_STATE_MSGS_CONVERSIONS_H_
 #define WHOLE_BODY_STATE_MSGS_CONVERSIONS_H_

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -108,7 +108,7 @@ class WholeBodyStateInterface {
    * @return The ROS message that contains the whole-body state
    * @note TODO: Contact type and contact location / velocity are not yet supported.
    */
-  whole_body_state_msgs::WholeBodyState writeToMessage(double t, const Eigen::VectorXd &q,
+  const whole_body_state_msgs::WholeBodyState& writeToMessage(double t, const Eigen::VectorXd &q,
                                                        const Eigen::VectorXd &v = Eigen::VectorXd(),
                                                        const Eigen::VectorXd &tau = Eigen::VectorXd(),
                                                        std::unordered_map<std::string, ContactState> contacts = {}) {

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -318,10 +318,12 @@ class WholeBodyStateInterface {
       throw std::invalid_argument("Expected msg.joints to be " + std::to_string(model_.njoints - 2) +
                                   " but received " + std::to_string(msg.joints.size()));
     }
-    if (msg.contacts.size() != contacts.size()) {
-      throw std::invalid_argument("Expected msg.contacts to be " + std::to_string(contacts.size()) + " but received " +
-                                  std::to_string(msg.contacts.size()));
-    }
+    // NB: We do not want to check contacts - they will get inserted into the map.
+    // if (msg.contacts.size() != contacts.size()) {
+    //   throw std::invalid_argument("Expected msg.contacts to be " + std::to_string(contacts.size()) + " but received
+    //   " +
+    //                               std::to_string(msg.contacts.size()));
+    // }
 
     t = msg.time;
 


### PR DESCRIPTION
This PR makes the following changes:
  1. Write the time information (import for MPC synchronization)
  2. Use the std::map information within the contacts argument (reduce unnecessary extra computation)
  3. Improve the documentation
  4. Add checks
  5. Initialize contact-state variable with NAN (needed for 2)