### PR TITLE
Fix enum assignation differing from whole_body_state_msgs

### DIFF
--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -76,7 +76,7 @@ struct ContactState {
       pinocchio::Force(Eigen::Vector3d(NAN, NAN, NAN), Eigen::Vector3d(NAN, NAN, NAN));  ///< Contact force
   Eigen::Vector3d surface_normal = Eigen::Vector3d(NAN, NAN, NAN);  ///< Normal vector at the contact surface
   double surface_friction;                                          ///< Friction coefficient of the contact surface
-  std::size_t type;                                                 ///< Contact type
+  ContactTypeEnum type = ContactTypeEnum::LOCOMOTION;               ///< Contact type
   ContactStateEnum state = ContactStateEnum::UNKNOWN;               ///< Classified contact state
 };
 
@@ -429,19 +429,27 @@ class WholeBodyStateInterface {
       contacts[contact.name].surface_normal.y() = contact.surface_normal.y;
       contacts[contact.name].surface_normal.z() = contact.surface_normal.z;
       contacts[contact.name].surface_friction = contact.friction_coefficient;
-      if (contact.type == contact.LOCOMOTION) {
-        contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::LOCOMOTION;
-      } else if (contact.type == contact.MANIPULATION) {
-        contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::MANIPULATION;
+      switch (contact.type) {
+        case contact.LOCOMOTION:
+          contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::LOCOMOTION;
+          break;
+        case contact.MANIPULATION:
+          contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::MANIPULATION;
+          break;
       }
-      if (contact.status == contact.UNKNOWN) {
-        contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::UNKNOWN;
-      } else if (contact.status == contact.ACTIVE) {
-        contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::CLOSED;
-      } else if (contact.status == contact.INACTIVE) {
-        contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::OPEN;
-      } else if (contact.status == contact.SLIPPING) {
-        contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::SLIPPING;
+      switch (contact.status) {
+        case contact.UNKNOWN:
+          contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::UNKNOWN;
+          break;
+        case contact.ACTIVE:
+          contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::CLOSED;
+          break;
+        case contact.INACTIVE:
+          contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::OPEN;
+          break;
+        case contact.SLIPPING:
+          contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::SLIPPING;
+          break;
       }
     }
   }

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -29,7 +29,7 @@ namespace whole_body_state_conversions {
 
 // Resolves to int8
 enum ContactTypeEnum { LOCOMOTION = 0, MANIPULATION = 1 };
-enum ContactStateEnum { UNKNOWN = -1, OPEN = 0, CLOSED = 1, SLIPPING = 2 };
+enum ContactStateEnum { UNKNOWN = 0, OPEN = 1, CLOSED = 2, SLIPPING = 3 };
 
 struct ContactState {
  public:

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -314,14 +314,19 @@ class WholeBodyStateInterface {
       msg.contacts[i].surface_normal.z = nsurf_tmp_.z();
       msg.contacts[i].friction_coefficient = surface_friction;
 
-      if (contact.state == whole_body_state_conversions::ContactStateEnum::UNKNOWN) {
-        msg.contacts[i].status = whole_body_state_msgs::ContactState::UNKNOWN;
-      } else if (contact.state == whole_body_state_conversions::ContactStateEnum::CLOSED) {
-        msg.contacts[i].status = whole_body_state_msgs::ContactState::ACTIVE;
-      } else if (contact.state == whole_body_state_conversions::ContactStateEnum::OPEN) {
-        msg.contacts[i].status = whole_body_state_msgs::ContactState::INACTIVE;
-      } else if (contact.state == whole_body_state_conversions::ContactStateEnum::SLIPPING) {
-        msg.contacts[i].status = whole_body_state_msgs::ContactState::SLIPPING;
+      switch (contact.state) {
+        case whole_body_state_conversions::ContactStateEnum::UNKNOWN:
+          msg.contacts[i].status = whole_body_state_msgs::ContactState::UNKNOWN;
+          break;
+        case whole_body_state_conversions::ContactStateEnum::OPEN:
+          msg.contacts[i].status = whole_body_state_msgs::ContactState::INACTIVE;
+          break;
+        case whole_body_state_conversions::ContactStateEnum::CLOSED:
+          msg.contacts[i].status = whole_body_state_msgs::ContactState::ACTIVE;
+          break;
+        case whole_body_state_conversions::ContactStateEnum::SLIPPING:
+          msg.contacts[i].status = whole_body_state_msgs::ContactState::SLIPPING;
+          break;
       }
 
       ++i;

--- a/include/whole_body_state_conversions/whole_body_state_interface.h
+++ b/include/whole_body_state_conversions/whole_body_state_interface.h
@@ -430,24 +430,24 @@ class WholeBodyStateInterface {
       contacts[contact.name].surface_normal.z() = contact.surface_normal.z;
       contacts[contact.name].surface_friction = contact.friction_coefficient;
       switch (contact.type) {
-        case contact.LOCOMOTION:
+        case whole_body_state_msgs::ContactState::LOCOMOTION:
           contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::LOCOMOTION;
           break;
-        case contact.MANIPULATION:
+        case whole_body_state_msgs::ContactState::MANIPULATION:
           contacts[contact.name].type = whole_body_state_conversions::ContactTypeEnum::MANIPULATION;
           break;
       }
       switch (contact.status) {
-        case contact.UNKNOWN:
+        case whole_body_state_msgs::ContactState::UNKNOWN:
           contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::UNKNOWN;
           break;
-        case contact.ACTIVE:
+        case whole_body_state_msgs::ContactState::ACTIVE:
           contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::CLOSED;
           break;
-        case contact.INACTIVE:
+        case whole_body_state_msgs::ContactState::INACTIVE:
           contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::OPEN;
           break;
-        case contact.SLIPPING:
+        case whole_body_state_msgs::ContactState::SLIPPING:
           contacts[contact.name].state = whole_body_state_conversions::ContactStateEnum::SLIPPING;
           break;
       }


### PR DESCRIPTION
cc: @cmastalli this should fix the observed issue. It now matches the message format again (https://github.com/loco-3d/whole_body_state_msgs/blob/f4e51443e9709ec22336a27e4b12d9a29d572a66/msg/ContactState.msg#L19-L23)